### PR TITLE
Update jest-pact to use new interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-vue": "^6.2.2",
     "flush-promises": "^1.0.2",
     "jest": "^25.3.0",
-    "jest-pact": "^0.5.2",
+    "jest-pact": "^0.5.3",
     "rimraf": "^3.0.2",
     "serverless": "^1.67.3",
     "sinon": "^9.0.2",

--- a/test/pact/Registration.test.ts
+++ b/test/pact/Registration.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import { Pact } from '@pact-foundation/pact'
-import { pactWith, PactOptions } from 'jest-pact'
+import { pactWith, JestPactOptions } from 'jest-pact'
 import { Context } from '@nuxt/types/app'
 
 import fixture from '~/fixture'
@@ -14,7 +14,7 @@ pactWith({
     log: path.resolve(process.cwd(), '.pacts/logs', 'pact.log'),
     dir: path.resolve(process.cwd(), '.pacts/pactFiles'),
     cors: true
-} as PactOptions, (provider: Pact) => {
+} as JestPactOptions, (provider: Pact) => {
 
   let membersAPIClient: MembersAPIClient;
 


### PR DESCRIPTION
Hi there,

We changed the type of the options object in jest-pact from `PactOptions` to `JestPactOptions`. 

This is a breaking change, but because we're in prerelease, it isn't a major version bump.

Anyway, here's a PR that updates the breaking change for you.